### PR TITLE
Revert python back from v3.10 to v3.8 for shadho compatibility

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -59,3 +59,13 @@ jobs:
           uses: actions/checkout@v2
         - name: Test Parrot Binary + CVMFS Install
           run:  ./parrot-cvmfs-job.sh
+  
+  shadho-job:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Test Shadho Integration with Work Queue
+        run: ./shadho-test.sh
+

--- a/.shadhorc
+++ b/.shadhorc
@@ -1,0 +1,22 @@
+[global]
+wrapper = shadho_worker.py
+utils = shadho_utils.py
+output = out.tar.gz
+result_file = performance.json
+optimize = loss
+param_file = hyperparameters.json
+backend = json
+manager = workqueue
+
+[workqueue]
+port = 9123
+name = shadho_master
+shutdown = True
+logfile = shadho_master.log
+debugfile = shadho_master.debug
+password = False
+
+[backend]
+type = sql
+url = sqlite:///:memory:
+

--- a/shadho-test.sh
+++ b/shadho-test.sh
@@ -16,6 +16,9 @@ conda install -c conda-forge ndcctools python=3.8 -y
 conda install pip -y	#shadho is installed through pip
 python -m pip install shadho
 
+#ensure that shadho config file is in home directory, so shadho can find it later (there's no option to disable shadho finding its config file)
+cp .shadhorc $HOME/.shadhorc
+
 #run work_queue_worker. This command is heuristic and based on shadho code.
 $CONDA_PREFIX/bin/work_queue_worker -M shadho-wq-packaging-test-$USER --cores 1 --single-shot &
 

--- a/shadho-test.sh
+++ b/shadho-test.sh
@@ -19,6 +19,9 @@ python -m pip install shadho
 #ensure that shadho config file is in home directory, so shadho can find it later (there's no option to disable shadho finding its config file)
 cp .shadhorc $HOME/.shadhorc
 
+#ensure that shadho working dir is created
+mkdir $HOME/.shadho
+
 #run work_queue_worker. This command is heuristic and based on shadho code.
 $CONDA_PREFIX/bin/work_queue_worker -M shadho-wq-packaging-test-$USER --cores 1 --single-shot &
 

--- a/shadho-test.sh
+++ b/shadho-test.sh
@@ -12,7 +12,7 @@ conda create --name shadho-wq-packaging-test -y
 conda activate shadho-wq-packaging-test
 
 #install ndcctools and shadho
-conda install -c conda-forge ndcctools -y
+conda install -c conda-forge ndcctools python=3.8 -y
 conda install pip -y	#shadho is installed through pip
 python -m pip install shadho
 


### PR DESCRIPTION
 SHADHO depends on package pyrameter , which uses object Sequence in library collections , which is deprecated since python3.3 and removed since python3.9 . Reverting python back to v3.8 solves the issue.