### PR TITLE
Daily test of wq-example.py from coffea documentation

### DIFF
--- a/coffea.sh
+++ b/coffea.sh
@@ -16,12 +16,20 @@ conda-pack --name coffea-env --output coffea-env.tar.gz
 
 echo "*** Starting a single WQ worker"
 work_queue_worker -d all -o worker.log localhost 9123 &
+# acquire PID of worker to kill it later
+STATIC_WORKER_PID=$!
 
 echo "*** Downloading current wq-example.py from coffea documentation"
 wget https://raw.githubusercontent.com/CoffeaTeam/coffea/master/docs/source/wq-example.py -O coffea-test-downloaded.py
 
 echo "*** Execute static Coffea Application currently located in repository"
 python coffea-test.py
+
+echo "*** Killing old worker and starting new one to run downloaded Coffea example"
+kill $STATIC_WORKER_PID
+echo "*** Starting a single WQ worker"
+work_queue_worker -d all -o worker.log localhost 9123 &
+
 
 echo "*** Execute most recent work_queue example Coffea Application currently located in the Coffea GitHub"
 python coffea-test-downloaded.py

--- a/coffea.sh
+++ b/coffea.sh
@@ -25,9 +25,10 @@ wget https://raw.githubusercontent.com/CoffeaTeam/coffea/master/docs/source/wq-e
 echo "*** Execute static Coffea Application currently located in repository"
 python coffea-test.py
 
-echo "*** Killing old worker and starting new one to run downloaded Coffea example"
+echo "*** Killing old worker and starting new one to run downloaded Coffea example. Also deletes the wq-factory folder to avoid a fatal error"
 kill $STATIC_WORKER_PID
 rm -rfd wq-factory-*
+
 echo "*** Starting a single WQ worker"
 work_queue_worker -d all -o worker.log localhost 9123 &
 

--- a/coffea.sh
+++ b/coffea.sh
@@ -30,7 +30,7 @@ kill $STATIC_WORKER_PID
 echo "*** Starting a single WQ worker"
 work_queue_worker -d all -o worker.log localhost 9123 &
 
-
+sleep 5
 echo "*** Execute most recent work_queue example Coffea Application currently located in the Coffea GitHub"
 python coffea-test-downloaded.py
 

--- a/coffea.sh
+++ b/coffea.sh
@@ -12,6 +12,7 @@ conda create -y --name coffea-env
 conda activate coffea-env
 conda install -y python=3.8.3 six dill
 conda install -y -c conda-forge coffea ndcctools xrootd
+echo "*** All packages successfully installed"
 
 echo "*** Create the Conda-Pack tarball"
 conda-pack --name coffea-env --output coffea-env.tar.gz

--- a/coffea.sh
+++ b/coffea.sh
@@ -8,11 +8,8 @@ CONDA_BASE=$(conda info --base)
 . $CONDA_BASE/etc/profile.d/conda.sh
 
 echo "*** Install Conda and Pip packages"
-conda create -y --name coffea-env
+conda create -y --name coffea-env -c conda-forge --strict-channel-priority python=3.9 six dill coffea ndcctools xrootd
 conda activate coffea-env
-conda install -y python=3.8.3 six dill
-conda install -y -c conda-forge coffea ndcctools xrootd
-echo "*** All packages successfully installed"
 
 echo "*** Create the Conda-Pack tarball"
 conda-pack --name coffea-env --output coffea-env.tar.gz
@@ -28,5 +25,4 @@ python coffea-test.py
 
 echo "*** Execute most recent work_queue example Coffea Application currently located in the Coffea GitHub"
 python coffea-test-downloaded.py
-
 

--- a/coffea.sh
+++ b/coffea.sh
@@ -19,7 +19,13 @@ conda-pack --name coffea-env --output coffea-env.tar.gz
 echo "*** Starting a single WQ worker"
 work_queue_worker -d all -o worker.log localhost 9123 &
 
-echo "*** Execute Coffea Application"
+echo "*** Downloading current wq-example.py from coffea documentation"
+wget https://raw.githubusercontent.com/CoffeaTeam/coffea/master/docs/source/wq-example.py -O coffea-test-downloaded.py
+
+echo "*** Execute static Coffea Application currently located in repository"
+python coffea-test.py
+
+echo "*** Execute most recent work_queue example Coffea Application currently located in the Coffea GitHub"
 python coffea-test.py
 
 

--- a/coffea.sh
+++ b/coffea.sh
@@ -26,6 +26,6 @@ echo "*** Execute static Coffea Application currently located in repository"
 python coffea-test.py
 
 echo "*** Execute most recent work_queue example Coffea Application currently located in the Coffea GitHub"
-python coffea-test.py
+python coffea-test-downloaded.py
 
 

--- a/coffea.sh
+++ b/coffea.sh
@@ -27,6 +27,7 @@ python coffea-test.py
 
 echo "*** Killing old worker and starting new one to run downloaded Coffea example"
 kill $STATIC_WORKER_PID
+rm -rfd wq-factory-*
 echo "*** Starting a single WQ worker"
 work_queue_worker -d all -o worker.log localhost 9123 &
 


### PR DESCRIPTION
This change downloads the current wq-example.py as shown on the coffea documentation for the work_queue executor and runs it as the test. This is so that if anything changes in coffea and breaks the example, we will know when the test runs.