### PR TITLE
TaskVine: Update integration test with Parsl

### DIFF
--- a/parsl-vine-test.py
+++ b/parsl-vine-test.py
@@ -13,7 +13,7 @@ vine_config = parsl.config.Config(
             port=9124,
             project_name="vine_parsl_integration_test",
             shared_fs=False,
-            full_debug = True,
+            full_debug=True,
         )
     ] 
 )

--- a/parsl_vine.sh
+++ b/parsl_vine.sh
@@ -19,16 +19,7 @@ cleanup() {
 CONDA_BASE=$(conda info --base)
 . $CONDA_BASE/etc/profile.d/conda.sh
 
-# Create local conda environment that can compile and install CCTools on the master branch,
-# this listing of packages can be found on CCTools installation webpage (install from GitHub):
-conda create --yes --prefix ${CONDA_ENV} -c conda-forge --strict-channel-priority python=3.9 ndcctools git
-
-# Install Parsl manually from tphung's PR
-conda run --prefix ${CONDA_ENV} git clone https://github.com/tphung3/parsl.git ${LOCAL_PARSL_SRC}
-cd ${LOCAL_PARSL_SRC}
-conda run --prefix ../${CONDA_ENV} git checkout taskvine-integration
-conda run --prefix ../${CONDA_ENV} pip install . -r test-requirements.txt -r requirements.txt
-cd -
+conda create --yes --prefix ${CONDA_ENV} -c conda-forge --strict-channel-priority python=3.9 ndcctools parsl
 
 # Run Parsl application with TaskVine.
 # Note that it internally uses the local provider to start 1 worker.


### PR DESCRIPTION
The new test will pull ndcctools and parsl packages from conda.