### PR TITLE
vine/wq: cleanup parsl on exit

### DIFF
--- a/test-parsl-vine.py
+++ b/test-parsl-vine.py
@@ -61,9 +61,11 @@ def run(config, exec_name):
     
     if value==expected:
             print(f"Got expected value of {value}")
+            parsl.dfk().cleanup()
             sys.exit(0)
     else:
             print(f"Got incorrect value of {value}!")
+            parsl.dfk().cleanup()
             sys.exit(1)
 
 if __name__ == '__main__':

--- a/test-parsl-vine.py
+++ b/test-parsl-vine.py
@@ -58,7 +58,11 @@ def run(config, exec_name):
     print("Executing Workflow")
     value = total.result()
     expected = 9900
-    
+   
+    # need to manually call parsl.dfk().cleanup() to cleanly end submit/factory process.
+    # previously this call was included in the parsl atexit handler, however it 
+    # was removed due to runtime errors in Python 3.12+ when forks are attempted
+    # from atexit handlers. 
     if value==expected:
             print(f"Got expected value of {value}")
             parsl.dfk().cleanup()

--- a/test-parsl-wq.py
+++ b/test-parsl-wq.py
@@ -54,6 +54,10 @@ def run(config, exec_name):
     value = total.result()
     expected = 9900
     
+    # need to manually call parsl.dfk().cleanup() to cleanly end submit process.
+    # previously this call was included in the parsl atexit handler, however it 
+    # was removed due to runtime errors in Python 3.12+ when forks are attempted
+    # from atexit handlers. 
     if value==expected:
             print(f"Got expected value of {value}")
             parsl.dfk().cleanup()

--- a/test-parsl-wq.py
+++ b/test-parsl-wq.py
@@ -56,9 +56,11 @@ def run(config, exec_name):
     
     if value==expected:
             print(f"Got expected value of {value}")
+            parsl.dfk().cleanup()
             sys.exit(0)
     else:
             print(f"Got incorrect value of {value}!")
+            parsl.dfk().cleanup()
             sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
after a modification to parsl _atexit handling, we need to manually call cleanup before exiting the python process in order for the TaskVine and WQ submit processes to end. 